### PR TITLE
Updated gitignore to ignore Python venv, test, coverage, and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,22 @@
 __pycache__/
 *.pyc
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Python test and coverage artifacts
+.pytest_cache/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# Python tooling caches
+.mypy_cache/
+.ruff_cache/
+
+# Build artifacts
+build/
+dist/


### PR DESCRIPTION

**Summary**
  Updates .gitignore to prevent accidentally committing local Python environment files and common generated
  artifacts from testing, coverage, and build workflows.

  **Changes**
  - Ignore local virtual environments: .venv/, venv/, env/
  - Ignore pytest and coverage outputs: .pytest_cache/, .coverage, .coverage.*, coverage.xml, htmlcov/
  - Ignore Python tool caches: .mypy_cache/, .ruff_cache/
  - Ignore generic build outputs: build/, dist/

  **Why**
  Running local setup and tests in this repo generates files that should remain untracked. These entries reduce
  noise in git status and lower the risk of accidentally committing machine-local or generated artifacts.

  Validation
  - Confirmed generated local artifacts like .venv/ and .pytest_cache/ are now covered by .gitignore rules.